### PR TITLE
Remove trust indicators and reduce project counts

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -30,12 +30,12 @@ export const allservices = [
 • Interior remodeling and space optimization
 • Clear timeline and transparent pricing`,
     insights: [
-      "⭐️ Over 120 renovation projects completed successfully",
+      "⭐️ Over 45 renovation projects completed successfully",
       "⭐️ Average project delivery 10% ahead of schedule",
       "⭐️ Client satisfaction rating of 4.9/5",
     ],
     stats: [
-      { label: "Projects Completed", value: 120 },
+      { label: "Projects Completed", value: 45 },
       { label: "On-time Delivery (%)", value: 90 },
       { label: "Customer Satisfaction (%)", value: 98 },
     ],
@@ -53,12 +53,12 @@ export const allservices = [
 • Vendor coordination & procurement
 • Real-time progress tracking`,
     insights: [
-      "✅ 200+ sites delivered nationwide",
+      "✅ 40+ sites delivered nationwide",
       "✅ Zero safety incidents in last 3 years",
       "✅ Built 15M+ sqft of commercial space",
     ],
     stats: [
-      { label: "Sites Delivered", value: 200 },
+      { label: "Sites Delivered", value: 40 },
       { label: "Incident-Free Years", value: 3 },
       { label: "Sqft Built (M)", value: 15 },
     ],
@@ -81,7 +81,7 @@ export const allservices = [
       "💡 30% average cost savings via optimization",
     ],
     stats: [
-      { label: "Designs Delivered", value: 150 },
+      { label: "Designs Delivered", value: 35 },
       { label: "VR Walkthroughs Used", value: 75 },
       { label: "Cost Savings (%)", value: 30 },
     ],
@@ -122,12 +122,12 @@ export const allservices = [
 • Custom millwork & furnishings
 • Styling, art curation & soft-goods`,
     insights: [
-      "🎨 50+ residential and commercial projects",
+      "🎨 30+ residential and commercial projects",
       "🎨 Average project ROI uplift of 20%",
       "🎨 End-to-end styling by in-house design team",
     ],
     stats: [
-      { label: "Projects Styled", value: 50 },
+      { label: "Projects Styled", value: 30 },
       { label: "ROI Uplift (%)", value: 20 },
       { label: "Art Curations", value: 200 },
     ],

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -55,28 +55,6 @@ const Services = () => {
             </p>
           </motion.div>
 
-          {/* Trust Indicators */}
-          <motion.div 
-            variants={slideUpVariants}
-            className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16"
-          >
-            <div className="text-center">
-              <div className="text-3xl md:text-4xl font-bold text-primary-500 mb-2">200+</div>
-              <div className="text-sm text-secondary-600 uppercase tracking-wide">Projects Completed</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl md:text-4xl font-bold text-primary-500 mb-2">5+</div>
-              <div className="text-sm text-secondary-600 uppercase tracking-wide">Years Experience</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl md:text-4xl font-bold text-primary-500 mb-2">98%</div>
-              <div className="text-sm text-secondary-600 uppercase tracking-wide">Client Satisfaction</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl md:text-4xl font-bold text-primary-500 mb-2">24/7</div>
-              <div className="text-sm text-secondary-600 uppercase tracking-wide">Customer Support</div>
-            </div>
-          </motion.div>
         </motion.div>
         
         {/* Services Grid */}


### PR DESCRIPTION
## Purpose
The user requested to remove the trust indicators section (200+ Projects Completed, 5+ Years Experience, 98% Client Satisfaction, 24/7 Customer Support) from the home page expertise section and reduce project completion numbers to be under 50 across all service cards.

## Code changes
- **Removed trust indicators section**: Deleted the entire grid component displaying 200+ Projects Completed, 5+ Years Experience, 98% Client Satisfaction, and 24/7 Customer Support from the Services component
- **Updated project counts in service data**: Reduced project completion numbers across all services:
  - Renovation projects: 120 → 45
  - Sites delivered: 200 → 40  
  - Designs delivered: 150 → 35
  - Projects styled: 50 → 30
- **Updated insights text**: Modified corresponding insight descriptions to reflect the new lower project counts

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/be2d9640cc184c4897e251252c04da26/pulse-haven)

👀 [Preview Link](https://be2d9640cc184c4897e251252c04da26-pulse-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>be2d9640cc184c4897e251252c04da26</projectId>-->
<!--<branchName>pulse-haven</branchName>-->